### PR TITLE
 TypeError in get_label function fix

### DIFF
--- a/site/en/tutorials/load_data/images.ipynb
+++ b/site/en/tutorials/load_data/images.ipynb
@@ -824,7 +824,7 @@
         "  # The second to last is the class-directory\n",
         "  one_hot = parts[-2] == class_names\n",
         "  # Integer encode the label\n",
-        "  return tf.argmax(one_hot)"
+        "  return tf.argmax(tf.cast(one_hot,dtype=tf.int16))"
       ]
     },
     {


### PR DESCRIPTION
While executing load images tutorial notebook, if got TypeError in get_label function, i manage to solve that using type casting (using tf.cast). So i suggesting the change.
Please! ignore if that's not the case.

Here is the summary of error

TypeError: in user code:

    <ipython-input-17-09797538ce85>:2 process_path  *
        label = get_label(file_path)
    <ipython-input-15-dfe3c4e7afec>:7 get_label  *
        return tf.argmax(one_hot)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/math_ops.py:173 argmax_v2  **
        return gen_math_ops.arg_max(input, axis, name=name, output_type=output_type)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/gen_math_ops.py:849 arg_max
        name=name)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/op_def_library.py:578 _apply_op_helper
        param_name=input_name)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/op_def_library.py:61 _SatisfiesTypeConstraint
        ", ".join(dtypes.as_dtype(x).name for x in allowed_list)))

    TypeError: Value passed to parameter 'input' has DataType bool not in list of allowed values: float32, float64, int32, uint8, int16, int8, complex64, int64, qint8, quint8, qint32, bfloat16, uint16, complex128, float16, uint32, uint64

Thanks